### PR TITLE
feature: Pass client configuration to `mocha.setup method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,28 @@ module.exports = function(config) {
 };
 ```
 
+If you want to pass configuration options directly to mocha you can
+do this in the following way
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    frameworks: ['mocha'],
+
+    files: [
+      '*.js'
+    ],
+
+    client: {
+      mocha: {
+        ui: 'tdd'
+      }
+    }
+  });
+};
+```
+
 ----
 
 For more information on Karma see the [homepage].

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -86,3 +86,35 @@ var createMochaStartFn = function(mocha) {
     mocha.run();
   };
 };
+
+// Default configuration
+var mochaConfig = {
+  reporter: createMochaReporterConstructor(window.__karma__),
+  ui: 'bdd',
+  globals: ['__cov*']
+};
+
+// Pass options from client.mocha to mocha
+var createConfigObject = function(karma) {
+  if (!karma.config || !karma.config.mocha) {
+    return mochaConfig;
+  }
+
+  // Copy all properties to mochaConfig
+  for (var key in karma.config.mocha) {
+
+    // except for reporter
+    if (key === 'reporter') {
+      return;
+    }
+
+    // and merge the globals if they exist.
+    if (key === 'globals' && karma.config.mocha[key].concat === 'function') {
+      return mochaConfig.globals.concat(karma.config.mocha[key]);
+    }
+
+    mochaConfig[key] = karma.config.mocha[key];
+  }
+  return mochaConfig;
+};
+

--- a/src/adapter.wrapper
+++ b/src/adapter.wrapper
@@ -4,6 +4,5 @@
 
 
 window.__karma__.start = createMochaStartFn(window.mocha);
-window.mocha.setup({reporter: createMochaReporterConstructor(window.__karma__), ui: 'bdd',
-    globals: ['__cov*']});
+window.mocha.setup(createConfigObject(window.__karma__));
 })(window);


### PR DESCRIPTION
Now all configuration in `client.config.mocha` is passed to the
setup method of mocha. The default ui style of `'bdd'` is still
set if nothing else is supplied. Also the reporter will be always
overridden as this needs to be our custom one.

Fixes #13.

---

I know that tests are missing but I'm not sure how it's possible to test this with the current testing setup.
