### PR TITLE
Feature create mocha config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,33 +34,36 @@ module.exports = function(config) {
 };
 ```
 
-## Custom Configuration
+## Custom Configuration -- (not currently possible until someone creates a way to pass the mocha.conf.js file to mocha... );
 If you want to customize your mocha experience you can do something like:
 
 ```js
-// In your karma.conf.js
+// In your mocha.conf.js file change the options in the Configuration object:
 
-module.exports = function(config) {
-var OPTIONS = {
-                grep
-            ,   ui
-            ,   reporter
-            ,   timeout
-            ,   invert
-            ,   ignoreLeaks
-            ,   growl
-            ,   globals
-	}
-  config.set({
-    frameworks: ['mocha'],
-
-    files: [
-      '*.js'
-    ],
-    mocha.theMagicMethodThatIsUsedToInsertUserConfiguredVariables(OPTIONS);
-  });
+var Configuration = {
+	// show colors?
+	colors : [true]
+	// enable node's debugger? (synonym for node --debug)
+	,   debug: [false]
+	//  do you want to pass in a given comma-delimited global [names]?
+	,	    globals : ["none"]
+	// do you want to only run tests matching <pattern>? blank for all
+	,   grep : ["none"]
+	//  do you want to use growl for notifications? (I think this is UNIX only...)
+	,   growl : [false]
+	//  (I have no idea what leaks are)
+	,   ignoreLeaks : [true]
+	//  if grep has values and if matches are found, do you want to invert the matches?
+	,   invert : ["none"]
+	// dot | doc | spec | json | progress | list | tap | landing | xunit | html-cov | json-cov | min | json-stream | markdown | nyan <-- as in nyan cat.
+	,   reporter : ["dot"]
+	//  set test-case timeout in milliseconds
+	,   timeout : 2000
+	// bdd | tdd | exports
+	,   ui : ["bdd"]
 };
 
+//don't mess with the stuff below this 
 ```
 
 

--- a/mocha.conf.js
+++ b/mocha.conf.js
@@ -26,6 +26,8 @@ var Configuration = {
 	,   ui : ["bdd"]
 };
 
+//don't mess with the stuff below this
+
 var finalConfig = (function removeExtraProperties(configurationObject){
 	var configuration = configurationObject;
 	if ( configuration ){


### PR DESCRIPTION
## Creates / adds a mocha.conf.js

The mocha.conf.js file is meant to serve the same purpose to mocha as the karma.conf.js file serves to karma. 
Yeah that's strangely worded; deal with it. :-P

NOTE: I don't know how to pass the mocha.conf.js file to karma... so someone else should fork my branch and integrate it. 
