### PR TITLE
Fix: duplicate test failure messages.

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -45,7 +45,7 @@ var createMochaReporterConstructor = function(tc) {
     });
 
     runner.on('fail', function(test, error) {
-      if ('hook' === test.type || error.uncaught) {
+      if ('hook' === test.type) {
         test.$errors = [formatError(error)];
         runner.emit('test end', test);
       } else {

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -142,7 +142,27 @@ describe('adapter mocha', function() {
         runner.emit('fail', mockMochaHook, {message: 'hook failed'});
 
         expect(tc.result).toHaveBeenCalled();
-      })
+      });
+      
+      it('should end the test only once on uncaught exceptions', function() {
+        spyOn(tc, 'result').andCallFake(function(result) {
+          expect(result.success).toBe(false);
+          expect(result.skipped).toBe(false);
+          expect(result.log).toEqual(['Uncaught error.']);
+        });
+
+        var mockMochaResult = {
+          parent: {title: 'desc2', root: true},
+          state: "failed",
+          title: 'should do something'
+        };
+
+        runner.emit('test', mockMochaResult);
+        runner.emit('fail', mockMochaResult, {message: 'Uncaught error.', uncaught: true});
+        runner.emit('test end', mockMochaResult);
+
+        expect(tc.result.calls.length).toBe(1);
+      });
     })
   });
 });


### PR DESCRIPTION
Change the adapter implementation to not emit `test end` for failures resulting
from unhandled exceptions (mocha already does this -- see
https://github.com/visionmedia/mocha/blob/master/mocha.js#L4816).

Fixes #16.
