### PR TITLE
Doc:update config sample used with grunt-karma

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ module.exports = function(config) {
 };
 ```
 
+Or if you ues karma with grunt, you should add the mocha configuration
+to the Gruntfile.js like this, because the plugin grunt-karma would
+overwrite this value
+
+```js
+// Gruntfile.js
+
+grunt.initConfig({
+  karma: {
+    test: {
+      client: {
+        mocha: {
+          bail: true,
+          ui: 'bdd'
+        }
+      },
+      configFile: 'karma.conf.js'
+    }
+  }
+});
+```
+
+
 ----
 
 For more information on Karma see the [homepage].


### PR DESCRIPTION
Because cli option value has higher priority than those in karma.conf.js file and there's already the client config In grunt-karma task file, client config value in karma.conf.js would be overwritten.
