### PR TITLE
Fix: grep mocha

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ module.exports = function(config) {
 };
 ```
 
+If you want run only some tests matching a given pattern you can
+do this in the following way
+
+```sh
+karma start &
+karma run -- --grep=<pattern>
+```
+
+`--grep` argument pass directly to mocha
+
 ----
 
 For more information on Karma see the [homepage].

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -80,8 +80,11 @@ var createMochaReporterConstructor = function(tc) {
 
 var createMochaStartFn = function(mocha) {
   return function(config) {
-    if(config && config.args && config.args.grep){
-      mocha.grep(config.args.grep);
+    if (config && config.args) {
+      config.args.join(' ').replace(/--grep[\s|=]+(\S+)?\s*/, function(match, grep) {
+        mocha.grep(grep);
+        return match;
+      });
     }
     mocha.run();
   };

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -143,7 +143,7 @@ describe('adapter mocha', function() {
 
         expect(tc.result).toHaveBeenCalled();
       });
-      
+
       it('should end the test only once on uncaught exceptions', function() {
         spyOn(tc, 'result').andCallFake(function(result) {
           expect(result.success).toBe(false);
@@ -163,6 +163,43 @@ describe('adapter mocha', function() {
 
         expect(tc.result.calls.length).toBe(1);
       });
-    })
+    });
+  });
+
+  describe('createMochaStartFn', function() {
+    beforeEach(function() {
+      this.mockMocha = {
+        grep: function(){},
+        run: function(){},
+      };
+    });
+
+    it('should pass grep argument to mocha', function() {
+      spyOn(this.mockMocha, 'grep');
+
+      createMochaStartFn(this.mockMocha)({
+        args: ['--grep', 'test']
+      });
+
+      expect(this.mockMocha.grep).toHaveBeenCalledWith('test');
+    });
+
+    it('should pass grep argument to mocha if we called the run with --grep=xxx', function() {
+      spyOn(this.mockMocha, 'grep');
+
+      createMochaStartFn(this.mockMocha)({
+        args: ['--grep=test']
+      });
+
+      expect(this.mockMocha.grep).toHaveBeenCalledWith('test');
+    });
+
+    it('should not require client arguments', function() {
+      var that = this;
+
+      expect(function(){
+        createMochaStartFn(that.mockMocha)({});
+      }).not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
Restored the possibility of grepping mocha tests from terminal

``` sh
karma start --single-run=false &
karma run -- --grep <pattern>
```

Related topic:
https://github.com/karma-runner/karma/pull/530#issuecomment-35129118
