### PR TITLE
feat: Allow define html reporter on debug page. resolve #20

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,13 +4,17 @@ var createPattern = function(path) {
   return {pattern: path, included: true, served: true, watched: false};
 };
 
-var initMocha = function(files) {
+var initMocha = function(files, mochaConfig) {
   var mochaPath = path.dirname(require.resolve('mocha'));
   files.unshift(createPattern(__dirname + '/adapter.js'));
   files.unshift(createPattern(mochaPath + '/mocha.js'));
+
+  if (mochaConfig && mochaConfig.reporter) {
+    files.unshift(createPattern(mochaPath + '/mocha.css'));
+  }
 };
 
-initMocha.$inject = ['config.files'];
+initMocha.$inject = ['config.files', 'config.client.mocha'];
 
 module.exports = {
   'framework:mocha': ['factory', initMocha]

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "shared-karma-files": "git://github.com/karma-runner/shared-karma-files.git#82ae8d02"
   },
   "peerDependencies": {
-    "karma": ">=0.9",
+    "karma": ">=0.12.8",
     "mocha": "*"
   },
   "license": "MIT",

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -16,7 +16,22 @@ var formatError = function(error) {
 };
 
 
-var createMochaReporterConstructor = function(tc) {
+var createMochaReporterNode = function() {
+  var mochaRunnerNode = document.createElement('div');
+  mochaRunnerNode.setAttribute('id', 'mocha');
+  document.body.appendChild(mochaRunnerNode);
+};
+
+var haveMochaConfig = function(karma) {
+  return karma.config && karma.config.mocha;
+};
+
+var createMochaReporterConstructor = function(tc, pathname) {
+  // Set custom reporter on debug page
+  if (/debug.html$/.test(pathname) && haveMochaConfig(tc) && tc.config.mocha.reporter) {
+    createMochaReporterNode();
+    return tc.config.mocha.reporter;
+  }
 
   // TODO(vojta): error formatting
   return function(runner) {
@@ -107,7 +122,7 @@ var createMochaStartFn = function(mocha) {
 
 // Default configuration
 var mochaConfig = {
-  reporter: createMochaReporterConstructor(window.__karma__),
+  reporter: createMochaReporterConstructor(window.__karma__, window.location.pathname),
   ui: 'bdd',
   globals: ['__cov*']
 };

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -15,6 +15,35 @@ describe('adapter mocha', function() {
     sandbox.restore();
   });
 
+  describe('createMochaReporterConstructor', function(){
+    beforeEach(function() {
+      this.karma = new Karma(new MockSocket(), null, null, null, {search: ''});
+      this.karma.config = {
+        mocha: {
+          reporter: 'html'
+        }
+      };
+
+      sandbox.stub(window, 'createMochaReporterNode');
+    });
+
+    it('should take reporter from client config on debug page', function(){
+      expect(createMochaReporterConstructor(this.karma, '/debug.html')).to.equal('html');
+    });
+
+    it('should create node for mocha reporter', function(){
+      createMochaReporterConstructor(this.karma, '/debug.html');
+
+      expect(createMochaReporterNode.called).to.equal(true);
+    });
+
+    it('should define console reporter if does not pass reporter in config', function(){
+      this.karma.config.mocha.reporter = null;
+
+      expect(createMochaReporterConstructor(this.karma, '/debug.html')).not.to.equal(null);
+    });
+  });
+
   describe('reporter', function() {
     var runner, tc;
 


### PR DESCRIPTION
Plug the usual mocha reporter in debug mode.

Now we can define reporter for debug.html in karma.conf.js

``` js
client: {
  mocha: {
    reporter: 'html'
  }
}
```
