### PR TITLE
added info to the README on html reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ module.exports = function(config) {
 
     client: {
       mocha: {
+        reporter: 'html', // change Karma's debug.html to the mocha web reporter
         ui: 'tdd'
       }
     }


### PR DESCRIPTION
I didn't see anywhere in the README on how to activate Mocha's html reporter, so I dug around the source code to find out if it was supported.  Felt it would be helpful to show it off in case it helps others.
