### PR TITLE
--grep doesn't do regular expressions

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -110,11 +110,11 @@ var createMochaStartFn = function(mocha) {
         arrayReduce(clientArguments, function(isGrepArg, arg) {
           var match;
           if (isGrepArg) {
-            mocha.grep(arg);
+            mocha.grep(new RegExp(arg));
           } else if (arg === '--grep') {
             return true;
           } else if (match = /--grep=(.*)/.exec(arg)) {
-            mocha.grep(match[1]);
+            mocha.grep(new RegExp(match[1]));
           }
           return false;
         }, false);

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -249,7 +249,7 @@ describe('adapter mocha', function() {
         args: ['--grep', 'test test']
       });
 
-      expect(this.mockMocha.grep.getCall(0).args).to.deep.eq(['test test']);
+      expect(this.mockMocha.grep.getCall(0).args).to.deep.eq([/test test/]);
     });
 
     it('should pass grep argument to mocha if we called the run with --grep=xxx', function() {
@@ -259,7 +259,7 @@ describe('adapter mocha', function() {
         args: ['--grep=test test']
       });
 
-      expect(this.mockMocha.grep.getCall(0).args).to.deep.eq(['test test']);
+      expect(this.mockMocha.grep.getCall(0).args).to.deep.eq([/test test/]);
     });
 
     it('should pass grep argument to mocha if config.args contains property grep', function(){


### PR DESCRIPTION
The mocha API, takes either a string or a regexp. If it's a string then it escapes it before turning it into a regexp. See here:

https://github.com/mochajs/mocha/blob/ca84810498fe1b32d2ab237b1f0b98db4a9f9da5/lib/mocha.js#L230

The problem with this is that there is no way to pass a regexp to mocha using the `client.args` config in karma. This patch means that the `--grep` argument is now interpreted as a regular expression, and seems to be more inline with the documentation, especially when it says `['--grep', '<pattern>']`.