### PR TITLE
Filter suites/tests using the mocha grep option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,17 @@ module.exports = function(config) {
   config.set({
     ...
     client: {
-      args: ['--grep', '<pattern>'],
+      mocha:{
+        grep: '<pattern>',
+        ...
+      }
       ...
     }
   });
 };
 ```
 
-`--grep` argument pass directly to mocha
+The `grep` argument is passed directly to mocha.
 
 
 ----


### PR DESCRIPTION
I'm using karma programmatically so I'm generating the karma configuration file dynamically.
I was trying to add the ability to choose the pattern to pass to karma-mocha to filter the suite/tests to execute, so I did read the following in the README:

```js
module.exports = function(config) {
  config.set({
    ...
    client: {
      args: ['--grep', '<pattern>'],
      ...
    }
  });
};
```

But when I added that to my configuration it didn't work.

I've tried to update both karma and karma-mocha to the latest versions but no luck.

I've just ended up looking at the [mocha API](https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically) to figure out how to pass the grep option and it worked as a charm.
I thought it may be useful to share the thing back.