### PR TITLE
Updated mocha to v2.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "karma-mocha": "~0.2.1",
     "karma-sinon": "~1.0.3",
     "load-grunt-tasks": "^3.2.0",
-    "mocha": "^2.3.3",
+    "mocha": "^2.4.5",
     "shared-karma-files": "git://github.com/karma-runner/shared-karma-files.git#82ae8d02",
     "sinon": "^1.17.2"
   },


### PR DESCRIPTION
v2.3.3 of Mocha throws an unhelpful error when trying to compare to undefined. v2.4.5 has fixed this in the utils.stringify method. All tests pass with the updated version.