### PR TITLE
Include the assertion error data, instead of a serialized version of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ On the end of each test `karma-mocha` passes to `karma` result object with field
 * `assertionErrors` List of additional error info: 
     * `name` Error name.
     * `message` Error message.
-    * `actual` Actual data in assertion, serialized to string.
-    * `expected` Expected data in assertion, serialized to string.
+    * `actual` Actual data in assertion
+    * `expected` Expected data in assertion
     * `showDiff` True if it is configured by assertion to show diff.
 
 This object will be passed to test reporter.

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -14,23 +14,10 @@ var formatError = function (error) {
   return message
 }
 
-var processAssertionError = function (error_) {
-  var error
-
-  if (window.Mocha && error_.hasOwnProperty('showDiff')) {
-    error = {
-      name: error_.name,
-      message: error_.message,
-      showDiff: error_.showDiff
-    }
-
-    if (error.showDiff) {
-      error.actual = window.Mocha.utils.stringify(error_.actual)
-      error.expected = window.Mocha.utils.stringify(error_.expected)
-    }
+var processAssertionError = function (error) {
+  if (window.Mocha && error.hasOwnProperty('showDiff')) {
+    return error
   }
-
-  return error
 }
 
 // non-compliant version of Array::reduce.call (requires memo argument)

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -173,11 +173,14 @@ describe('adapter mocha', function () {
       it('should report failed mocha result', function () {
         sandbox.stub(tc, 'result', function (result) {
           expect(result.log).to.deep.eq(['Big trouble.', 'Another fail.'])
-          expect(result.assertionErrors).to.deep.eq([{
+          expect(result.assertionErrors).to.have.length(1)
+          expect(result.assertionErrors[0]).to.deep.eq({
             name: 'AssertionError',
             message: 'Big trouble.',
-            showDiff: false
-          }])
+            showDiff: false,
+            actual: 1,
+            expected: 2
+          })
         })
 
         var mockMochaResult = {
@@ -411,12 +414,12 @@ describe('adapter mocha', function () {
   })
 
   describe('processAssertionError', function () {
-    it('should create object from mocha error', function () {
+    it('should return the error object from mocha error', function () {
       var err = new Error()
       err.name = 'AssertionError'
       err.message = 'expected \'something\' to deeply equal \'something else\''
       err.showDiff = true
-      err.actual = {baz: 'baz', foo: null, bar: function () {}}
+      err.actual = {baz: 'baz', foo: null, bar: 'Something'}
       err.expected = {baz: 42, foo: undefined}
 
       var error = processAssertionError(err)
@@ -425,8 +428,8 @@ describe('adapter mocha', function () {
       expect(error.name).to.equal('AssertionError')
       expect(error.message).to.equal('expected \'something\' to deeply equal \'something else\'')
       expect(error.showDiff).to.be.true
-      expect(error.actual).to.equal('{\n  "bar": [Function]\n  "baz": "baz"\n  "foo": [null]\n}')
-      expect(error.expected).to.equal('{\n  "baz": 42\n  "foo": [undefined]\n}')
+      expect(error.actual).to.deep.equal({baz: 'baz', foo: null, bar: 'Something'})
+      expect(error.expected).to.deep.equal({baz: 42, foo: undefined})
     })
 
     it('should not create object from simple error', function () {
@@ -435,23 +438,6 @@ describe('adapter mocha', function () {
       var error = processAssertionError(err)
 
       expect(error).to.be.undefined
-    })
-
-    it('should not pass actual and expected if showDiff is off', function () {
-      var err = new Error()
-      err.message = 'expected \'something\' to deeply equal \'something else\''
-      err.showDiff = false
-      err.actual = {baz: 'baz', foo: null, bar: function () {}}
-      err.expected = {baz: 42, foo: undefined}
-
-      var error = processAssertionError(err)
-
-      expect(Object.keys(error)).to.be.eql(['name', 'message', 'showDiff'])
-      expect(error.name).to.equal('Error')
-      expect(error.message).to.equal('expected \'something\' to deeply equal \'something else\'')
-      expect(error.showDiff).to.be.false
-      expect(error).to.not.have.property('actual')
-      expect(error).to.not.have.property('expected')
     })
   })
 })


### PR DESCRIPTION
(This is sort of a extension of #85)

When I was writing a custom reporter ([this one](https://github.com/queicherius/karma-checkmark-reporter)), I was running into an issue generating diffs for the `actual` / `expected` data of assertion errors.

Currently, the implementation returns a serialized version of `actual` / `expected` (and uses a non-standard serializer to do so). In my opinion it would be more natural to just give the reporter the original error object, which is exactly what `mocha` itself does too. This breaks backwards compatibility for reporters that assume that `actual` / `expected` are strings.
