### PR TITLE
allow requiring files after mocha is initialised

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,14 @@ module.exports = function(config) {
 
     client: {
       mocha: {
-        reporter: 'html', // change Karma's debug.html to the mocha web reporter
-        ui: 'tdd'
+        // change Karma's debug.html to the mocha web reporter
+        reporter: 'html',
+
+        // require specific files after Mocha is initialized
+        require: [require.resolve('bdd-lazy-var/bdd_lazy_var_global')],
+
+        // custom ui, defined in required file above
+        ui: 'bdd-lazy-var/global',
       }
     }
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,13 @@ var createPattern = function (path) {
 var initMocha = function (files, mochaConfig) {
   var mochaPath = path.dirname(require.resolve('mocha'))
   files.unshift(createPattern(path.join(__dirname, 'adapter.js')))
+
+  if (mochaConfig.require && mochaConfig.require.map) {
+    mochaConfig.require.map(function (requirePath) {
+      return files.unshift(createPattern(requirePath))
+    })
+  }
+
   files.unshift(createPattern(path.join(mochaPath, 'mocha.js')))
 
   if (mochaConfig && mochaConfig.reporter) {

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -187,8 +187,8 @@ var createConfigObject = function (karma) {
 
   // Copy all properties to mochaConfig
   for (var key in karma.config.mocha) {
-    // except for reporter
-    if (key === 'reporter') {
+    // except for reporter or require
+    if (['reporter', 'require'].indexOf(key) >= 0) {
       continue
     }
 

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -392,6 +392,14 @@ describe('adapter mocha', function () {
       expect(createConfigObject(this.karma).reporter).not.to.eq('test')
     })
 
+    it('should ignore propertie require from client config', function () {
+      this.karma.config.mocha = {
+        require: 'test'
+      }
+
+      expect(createConfigObject(this.karma).require).not.to.eq('test')
+    })
+
     it('should merge the globals from client config if they exist', function () {
       this.karma.config.mocha = {
         globals: ['test']


### PR DESCRIPTION
I've been attempting to use a custom `mocha ui`, specifically https://github.com/stalniy/bdd-lazy-var. But as documented in #84, there is no way to `require` the dependency after the `Mocha` constant is initialised but before the adapter is initialised.

This PR allows adding a `require` array to `karma.config.js`, eg:
```js
client: {
  mocha: {
    ui: 'bdd-lazy-var/global',
    require: [ require.resolve('bdd-lazy-var/bdd_lazy_var_global') ]
  }
}
```

resolves #84