### PR TITLE
Fix: "remove mocha stack entries" was too greedy (+ test)

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -30,7 +30,7 @@ var formatError = function (error) {
     }
 
     // remove mocha stack entries
-    return stack.replace(/\n.+\/mocha\/mocha.js\?\w*:.+(?=(\n|$))/g, '')
+    return stack.replace(/\n.+\/mocha\/mocha\.js\?\w*:[\d:]+\)?(?=(\n|$))/g, '')
   }
 
   return message

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -287,6 +287,37 @@ describe('adapter mocha', function () {
 
         expect(tc.result.called).to.eq(true)
       })
+
+      it('should not remove escaped strings containing mocha stack entries', function () {
+        sandbox.stub(tc, 'result', function (result) {
+          var log = result.log[0]
+          expect(log).to.contain('something important that contains an escaped mocha stack trace')
+        })
+
+        var mockMochaResult = {
+          parent: {root: true}
+        }
+
+        var stack =
+          'something important that contains an escaped mocha stack trace at workFn (http://localhost:8080/base/app/bower_components/angular-mocks/angular-mocks.js?506e0a37bcd764ec63da3fd7005bf56592b3df32:2194)\\n at callFn (http://localhost:8080/base/node_modules/mocha/mocha.js?312499f61e38c4f82b2789b388ced378202a1e75:4471:21)\\n    at Hook.Runnable.run (http://localhost:8080/base/node_modules/mocha/mocha.js?312499f61e38c4f82b2789b388ced378202a1e75:4464:7)\\n\n' +
+          'at $httpBackend (http://localhost:8080/base/app/bower_components/angular-mocks/angular-mocks.js?506e0a37bcd764ec63da3fd7005bf56592b3df32:1149)\n' +
+          'at sendReq (http://localhost:8080/base/app/bower_components/angular/angular.js?7deca05396a4331b08f812e4962ef9df1d9de0b5:8408)\n' +
+          'at http://localhost:8080/base/app/bower_components/angular/angular.js?7deca05396a4331b08f812e4962ef9df1d9de0b5:8125\n' +
+          'at http://localhost:8080/base/test/client/spec/controllers/list/formCtrlSpec.js?67eaca0f801cf45a86802a262618a6cfdc6a47be:110\n' +
+          'at invoke (http://localhost:8080/base/app/bower_components/angular/angular.js?7deca05396a4331b08f812e4962ef9df1d9de0b5:4068)\n' +
+          'at workFn (http://localhost:8080/base/app/bower_components/angular-mocks/angular-mocks.js?506e0a37bcd764ec63da3fd7005bf56592b3df32:2194)\n' +
+          'at callFn (http://localhost:8080/base/node_modules/mocha/mocha.js?529c1ea3966a13c21efca5afe9a2317dafcd8abc:4338)\n' +
+          'at http://localhost:8080/base/node_modules/mocha/mocha.js?529c1ea3966a13c21efca5afe9a2317dafcd8abc:4331\n' +
+          'at next (http://localhost:8080/base/node_modules/mocha/mocha.js?529c1ea3966a13c21efca5afe9a2317dafcd8abc:4653)\n' +
+          'at http://localhost:8080/base/node_modules/mocha/mocha.js?529c1ea3966a13c21efca5afe9a2317dafcd8abc:4663\n' +
+          'at next (http://localhost:8080/base/node_modules/mocha/mocha.js?529c1ea3966a13c21efca5afe9a2317dafcd8abc:4601)\n'
+
+        runner.emit('test', mockMochaResult)
+        runner.emit('fail', mockMochaResult, {message: 'Another fail.', stack: stack})
+        runner.emit('test end', mockMochaResult)
+
+        expect(tc.result.called).to.eq(true)
+      })
     })
   })
 


### PR DESCRIPTION
When asserting on `Error`s and promises, my mismatch descriptions sometimes contain JSONified stack traces. But the `.+` in the "remove mocha stack entries" RegExp is too greedy an erases the whole assertion error in theses cases.

I added a test to demonstrate the issue and fixed it by using a more precise expression.