### PR TITLE
add timestamps to results

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ On the end of each test `karma-mocha` passes to `karma` result object with field
 * `skipped` True if test is skipped.
 * `time` Test duration.
 * `log` List of errors.
+* `startTime` Milliseconds since epoch that the test started
+* `endTime` Milliseconds since epoch that the test ended
 * `assertionErrors` List of additional error info: 
     * `name` Error name.
     * `message` Error message.
@@ -115,6 +117,7 @@ On the end of each test `karma-mocha` passes to `karma` result object with field
 
 This object will be passed to test reporter.
 
+NB. the start and end times are added by the adapter whereas the duration is calculated by Mocha - as such they probably will not match arithmetically. Ie. `endTime - startTime !== duration`. These fields have been added so that timestamped reports can be matched up with other timestamped reports from the target device (eg. memory profiling data collected outside the browser)
 
 ----
 

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -106,6 +106,7 @@ var createMochaReporterConstructor = function (tc, pathname) {
     })
 
     runner.on('test', function (test) {
+      test.$startTime = Date.now()
       test.$errors = []
       test.$assertionErrors = []
     })
@@ -139,7 +140,9 @@ var createMochaReporterConstructor = function (tc, pathname) {
         skipped: skipped,
         time: skipped ? 0 : test.duration,
         log: test.$errors || [],
-        assertionErrors: test.$assertionErrors || []
+        assertionErrors: test.$assertionErrors || [],
+        startTime: test.$startTime,
+        endTime: Date.now()
       }
 
       var pointer = test.parent

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -91,7 +91,11 @@ describe('adapter mocha', function () {
 
     describe('test end', function () {
       it('should report result', function () {
+        var beforeStartTime = Date.now()
+        var DURATION = 200
+
         sandbox.stub(tc, 'result', function (result) {
+          var afterEndTime = Date.now()
           expect(result.id).to.not.be.undefined
           expect(result.description).to.eq('should do something')
           expect(result.suite instanceof Array).to.eq(true)
@@ -99,17 +103,23 @@ describe('adapter mocha', function () {
           expect(result.skipped).to.to.eql(false)
           expect(result.log instanceof Array).to.eq(true)
           expect(result.assertionErrors instanceof Array).to.eq(true)
-          expect(result.time).to.eq(123)
+          expect(result.startTime).to.be.at.least(beforeStartTime)
+          expect(result.endTime - result.startTime).to.be.at.least(DURATION)
+          expect(result.endTime).to.be.at.most(afterEndTime)
+          expect(result.time).to.eq(DURATION)
         })
 
         var mockMochaResult = {
-          duration: 123,
+          duration: DURATION,
           parent: {title: 'desc2', parent: {title: 'desc1', root: true}, root: false},
           state: 'passed',
           title: 'should do something'
         }
 
         runner.emit('test', mockMochaResult)
+        // wait at least 200ms to get different start and end times
+        var afterStartTime = Date.now()
+        while (Date.now() - afterStartTime < DURATION) {}
         runner.emit('test end', mockMochaResult)
 
         expect(tc.result.called).to.eq(true)


### PR DESCRIPTION
I have a use case where I generate reports on a remote device that are timestamped using the clock on that device. I need to be able to match these timestamps to the test reports I generate from the karma test runs on the same device.

This pull request adds start and end times for tests that are generated in the target browser (as opposed to generating them in a reporter that would not necessarily be using the same clock)