### PR TITLE
Expose mocha test properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ module.exports = function(config) {
   config.set({
     ...
     client: {
-      mocha:{
-        grep: '<pattern>',
+      mocha: {
+        grep: '<pattern>', // passed directly to mocha
         ...
       }
       ...
@@ -94,7 +94,22 @@ module.exports = function(config) {
 };
 ```
 
-The `grep` argument is passed directly to mocha.
+If you want to expose test properties specific to `mocha`, you can use the `expose` option:
+
+```js
+module.exports = function(config) {
+  config.set({
+    ...
+    client: {
+      mocha: {
+        expose: ['body'] // This will be exposed in a reporter as `result.mocha.body`
+        ...
+      }
+      ...
+    }
+  });
+};
+```
 
 ## Internals
 
@@ -114,6 +129,7 @@ On the end of each test `karma-mocha` passes to `karma` result object with field
     * `actual` Actual data in assertion, serialized to string.
     * `expected` Expected data in assertion, serialized to string.
     * `showDiff` True if it is configured by assertion to show diff.
+* `mocha` An optional object listed if you use the `expose` option
 
 This object will be passed to test reporter.
 

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -151,6 +151,15 @@ var createMochaReporterConstructor = function (tc, pathname) {
         pointer = pointer.parent
       }
 
+      if (haveMochaConfig(tc) && tc.config.mocha.expose && tc.config.mocha.expose.forEach) {
+        result.mocha = {}
+        tc.config.mocha.expose.forEach(function (prop) {
+          if (test.hasOwnProperty(prop)) {
+            result.mocha[prop] = test[prop]
+          }
+        })
+      }
+
       tc.result(result)
     })
   }
@@ -212,8 +221,8 @@ var createConfigObject = function (karma) {
 
   // Copy all properties to mochaConfig
   for (var key in karma.config.mocha) {
-    // except for reporter or require
-    if (includes(['reporter', 'require'], key)) {
+    // except for reporter, require, or expose
+    if (includes(['reporter', 'require', 'expose'], key)) {
       continue
     }
 

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -225,6 +225,47 @@ describe('adapter mocha', function () {
 
         expect(tc.result.called).to.eq(true)
       })
+
+      it('should report mocha properties through the `expose` option', function () {
+        tc.config = {
+          mocha: {
+            expose: ['body', 'hello']
+          }
+        }
+
+        sandbox.stub(tc, 'result', function (result) {
+          expect(result.mocha.body).to.eq('function(){ expect(false).to.be(true) }')
+          expect(result.mocha.hello).to.eq('world')
+        })
+
+        var mockMochaResult = {
+          parent: {title: 'desc2', root: true},
+          title: 'should do something',
+          body: 'function(){ expect(false).to.be(true) }',
+          hello: 'world'
+        }
+
+        runner.emit('test end', mockMochaResult)
+
+        expect(tc.result.called).to.eq(true)
+      })
+
+      it('should not report mocha properties if `expose` is not configured', function () {
+        sandbox.stub(tc, 'result', function (result) {
+          expect(result.mocha).to.not.exist
+        })
+
+        var mockMochaResult = {
+          parent: {title: 'desc2', root: true},
+          title: 'should do something',
+          body: 'function(){ expect(false).to.be(true) }',
+          hello: 'world'
+        }
+
+        runner.emit('test end', mockMochaResult)
+
+        expect(tc.result.called).to.eq(true)
+      })
     })
 
     describe('fail', function () {
@@ -439,6 +480,14 @@ describe('adapter mocha', function () {
       }
 
       expect(createConfigObject(this.karma).require).not.to.eq('test')
+    })
+
+    it('should ignore property expose from client config', function () {
+      this.karma.config.mocha = {
+        expose: 'body'
+      }
+
+      expect(createConfigObject(this.karma).expose).not.to.eq('body')
     })
 
     it('should merge the globals from client config if they exist', function () {


### PR DESCRIPTION
One of my favorite features of Mocha is the `body` property they add to all of their test results, a stringified version of the test function. I'm working on a project that makes use of this property, and I wanted to contribute my solution to exposing mocha test properties.

This PR allows users to provide an `expose` option to their Mocha config. When reporting a test result to Karma, this feature will iterate through the keys listed in the `expose` array, and if a key is found on Mocha's raw test results, add it to the result object passed to `tc.result()`

```js
module.exports = function(config) {
  config.set({
    ...
    client: {
      mocha: {
        expose: ['body'] // exposed in a Karma reporter as `result.mocha.body`
        ...
      }
      ...
    }
  });
};
```