### PR TITLE
chore(ci): fix node v0.10 version in build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - stable
   - 4
-  - 0.10
+  - '0.10'
 
 before_install:
   - npm install -g npm


### PR DESCRIPTION
needs to be a string for yaml

![screenshot](https://cl.ly/0d0C1d1e1S0Y/Image%202016-10-30%20at%2021.20.57.png)