### PR TITLE
add peer dependency for mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "shared-karma-files": "git://github.com/karma-runner/shared-karma-files.git#82ae8d02",
     "sinon": "^1.17.2"
   },
+  "peerDependencies": {
+    "mocha": "^3.0.0"
+  },
   "license": "MIT",
   "contributors": [
     "Maksim Ryzhikov <rv.maksim@gmail.com>",


### PR DESCRIPTION
This plugin depends on mocha being installed, so I encoded this as a peer dependency. I left the devDependency in place to facilitate easily installing when installing development packages as well.