### PR TITLE
feat: allow `mocha.run()` to be opted out of with `autoRun=false`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,8 @@ function getMochaOpts (mochaConfig) {
       'timeout',
       'slow',
       'bail',
-      'ignoreLeaks'
+      'ignoreLeaks',
+      'autoRun'
     ].reduce(function (result, optName) {
       if (opts.hasOwnProperty(optName)) {
         result[optName] = opts[optName]

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -205,6 +205,10 @@ var createMochaStartFn = function (mocha) {
       if (clientArguments.grep) {
         mocha.grep(clientArguments.grep)
       }
+
+      if (clientArguments.autoRun === false) {
+        return
+      }
     }
 
     mocha.run()


### PR DESCRIPTION
This PR adds the facility for disabling automatic calling of `mocha.run()`. It returns early if `config.autoRun === false`, thereby stopping the call to `mocha.run()`. I need this for a project I'm working on that uses a lazy build system and we need to call `run` once all test modules have loaded.

Happy to add docs and tests, if people are happy to see this included.
