### PR TITLE
Don't use the root property to determine suite root.

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -154,7 +154,7 @@ var createMochaReporterConstructor = function (tc, pathname) {
       }
 
       var pointer = test.parent
-      while (!pointer.root) {
+      while (pointer.parent) {
         result.suite.unshift(pointer.title)
         pointer = pointer.parent
       }

--- a/test/src/adapter.spec.js
+++ b/test/src/adapter.spec.js
@@ -126,6 +126,24 @@ describe('adapter mocha', function () {
         expect(tc.result.called).to.eq(true)
       })
 
+      it('should not rely on the root property to determine root', function () {
+        sandbox.stub(tc, 'result', function (result) {
+          expect(result.suite).to.deep.eq([''])
+        })
+
+        var mockMochaResult = {
+          duration: 0,
+          parent: {title: '', parent: {title: 'desc1', root: true}, root: true},
+          state: 'passed',
+          title: 'should do something'
+        }
+
+        runner.emit('test', mockMochaResult)
+        runner.emit('test end', mockMochaResult)
+
+        expect(tc.result.called).to.eq(true)
+      })
+
       it('should report skipped result', function () {
         sandbox.stub(tc, 'result', function (result) {
           expect(result.skipped).to.eq(true)


### PR DESCRIPTION
The root property is problematic because Mocha sets it true if the
description of a suite is the empty string. However, Mocha runs
perfectly well with suites that have empty names. See:

https://github.com/mochajs/mocha/issues/2755

Instead of relying on the root property, rely on whether the parent
property is set. If not, then we are at the root.