### PR TITLE
Ensure "test end" is re-emitted on late uncaught test error

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -133,6 +133,7 @@ var createMochaReporterConstructor = function (tc, pathname) {
       } else {
         test.$errors.push(isDebugPage ? error : simpleError)
         if (assertionError) test.$assertionErrors.push(assertionError)
+        if (error.uncaught) { runner.emit('test end', test) }
       }
     })
 


### PR DESCRIPTION
There are edge cases where a test will trigger uncaught errors but after it has already passed (which is considered "unrecoverable" by mocha and triggers a abortion of the suite).
In that case mocha will emit the following signals in order:
- "test"
- "test end"
- "fail"
- "end"

https://github.com/mochajs/mocha/blob/master/lib/runner.js#L837

This makes karma-mocha complete the suite right away with exit code 0 although maybe only half of the tests ran. Mocha runner properly handles that and fail the test suite, and it seems like karma-jasmine have something as well https://github.com/karma-runner/karma-jasmine/blob/master/src/adapter.js#L213 

This PR updates the adapter to internally re-emit a "test end" on "fail" when the test is marked with uncaught errors. This makes the test suite fail before early abort and properly flags uncaught error responsible test. A side effect of this is having a second report for that test.

An other much simpler option could be to rely on`tc.error` within the "end" handler if there are any failures on the runner regardless the kind of failure, or to use it directly in the "fail" hook if the error is marked with "uncaught" (regardless during or after the test run).

Note:
It seems like this patch should fail one of the existing tests for uncaught exceptions "should end the test only once on uncaught exceptions". How much of a problem is it to have multiple "test end"  beside the two reports ?

I'm happy to update this with any alternative solution if having a second "test end" is problematic.