### PR TITLE
Chore/align node support same as karma - fix current failing CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - stable
-  - 4
-  - '0.10'
+  - 8
+  - 10
 
 before_install:
   - npm install -g npm

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "karma-sinon": "^1.0.3",
     "load-grunt-tasks": "^3.2.0",
     "mocha": "^3.0.0",
-    "mock-fs": "^3.12.1",
+    "mock-fs": "^4.10.1",
     "shared-karma-files": "git://github.com/karma-runner/shared-karma-files.git#82ae8d02",
     "sinon": "^1.17.2"
   },


### PR DESCRIPTION
### Reason

Current travisci builds are failing for:

1. node < 6, npm update of npm tries to install npm version 6 that does not support node <= 4.

```
9.74s$ npm install -g npm
/home/travis/.nvm/versions/node/v4.9.1/bin/npm -> /home/travis/.nvm/versions/node/v4.9.1/lib/node_modules/npm/bin/npm-cli.js
/home/travis/.nvm/versions/node/v4.9.1/bin/npx -> /home/travis/.nvm/versions/node/v4.9.1/lib/node_modules/npm/bin/npx-cli.js
npm@6.9.0 /home/travis/.nvm/versions/node/v4.9.1/lib/node_modules/npm
/home/travis/.nvm/versions/node/v4.9.1/lib/node_modules/npm/bin/npm-cli.js:84
      let notifier = require('update-notifier')({pkg})
      ^^^
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

2. node stable (12), mock-fs old version [support node up until version 7](https://github.com/tschaub/mock-fs/blob/664510404188c2798d62b87fda8512afdafc50a3/lib/index.js#L13) and emit support error.

```
$ npm run test:lib
> karma-mocha@1.3.0 test:lib /home/travis/build/karma-runner/karma-mocha
> mocha test/lib
/home/travis/build/karma-runner/karma-mocha/node_modules/mock-fs/lib/index.js:38
  throw new Error('Unsupported Node version: ' + nodeVersion);
  ^
Error: Unsupported Node version: 12.2.0
    at Object.<anonymous> (/home/travis/build/karma-runner/karma-mocha/node_modules/mock-fs/lib/index.js:38:9)
```

Current [karma travis ci ](https://github.com/karma-runner/karma/blob/master/.travis.yml#L3) is configured for node 8 and 10 testing. 

### Solution
- Change CI to check only node 8 and 10
- Update mock-fs library to support node > 7