### PR TITLE
Report fails without emit 'test end' event

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -80,6 +80,41 @@ var haveMochaConfig = function (karma) {
   return karma.config && karma.config.mocha
 }
 
+var reportTestResult = function (karma, test) {
+  var skipped = test.pending === true
+
+  var result = {
+    id: '',
+    description: test.title,
+    suite: [],
+    success: test.state === 'passed',
+    skipped: skipped,
+    pending: skipped,
+    time: skipped ? 0 : test.duration,
+    log: test.$errors || [],
+    assertionErrors: test.$assertionErrors || [],
+    startTime: test.$startTime,
+    endTime: Date.now()
+  }
+
+  var pointer = test.parent
+  while (!pointer.root) {
+    result.suite.unshift(pointer.title)
+    pointer = pointer.parent
+  }
+
+  if (haveMochaConfig(karma) && karma.config.mocha.expose && karma.config.mocha.expose.forEach) {
+    result.mocha = {}
+    karma.config.mocha.expose.forEach(function (prop) {
+      if (test.hasOwnProperty(prop)) {
+        result.mocha[prop] = test[prop]
+      }
+    })
+  }
+
+  karma.result(result)
+}
+
 var createMochaReporterConstructor = function (tc, pathname) {
   var isDebugPage = /debug.html$/.test(pathname)
 
@@ -129,7 +164,7 @@ var createMochaReporterConstructor = function (tc, pathname) {
       if (test.type === 'hook') {
         test.$errors = isDebugPage ? [error] : [simpleError]
         test.$assertionErrors = assertionError ? [assertionError] : []
-        runner.emit('test end', test)
+        reportTestResult(tc, test)
       } else {
         test.$errors.push(isDebugPage ? error : simpleError)
         if (assertionError) test.$assertionErrors.push(assertionError)
@@ -137,38 +172,7 @@ var createMochaReporterConstructor = function (tc, pathname) {
     })
 
     runner.on('test end', function (test) {
-      var skipped = test.pending === true
-
-      var result = {
-        id: '',
-        description: test.title,
-        suite: [],
-        success: test.state === 'passed',
-        skipped: skipped,
-        pending: skipped,
-        time: skipped ? 0 : test.duration,
-        log: test.$errors || [],
-        assertionErrors: test.$assertionErrors || [],
-        startTime: test.$startTime,
-        endTime: Date.now()
-      }
-
-      var pointer = test.parent
-      while (!pointer.root) {
-        result.suite.unshift(pointer.title)
-        pointer = pointer.parent
-      }
-
-      if (haveMochaConfig(tc) && tc.config.mocha.expose && tc.config.mocha.expose.forEach) {
-        result.mocha = {}
-        tc.config.mocha.expose.forEach(function (prop) {
-          if (test.hasOwnProperty(prop)) {
-            result.mocha[prop] = test[prop]
-          }
-        })
-      }
-
-      tc.result(result)
+      reportTestResult(tc, test)
     })
   }
 }

--- a/test/src/adapter.spec.js
+++ b/test/src/adapter.spec.js
@@ -290,6 +290,21 @@ describe('adapter mocha', function () {
         expect(tc.result.called).to.eq(true)
       })
 
+      it('should not emit test end on hook failure', function () {
+        const testEndStub = sandbox.stub()
+        runner.on('test end', testEndStub)
+
+        var mockMochaHook = {
+          type: 'hook',
+          title: 'scenario "before each" hook',
+          parent: {title: 'desc1', root: true}
+        }
+
+        runner.emit('hook', mockMochaHook)
+        runner.emit('fail', mockMochaHook, {message: 'hook failed'})
+        expect(testEndStub.called).to.eq(false)
+      })
+
       it('should end the test only once on uncaught exceptions', function () {
         sandbox.stub(tc, 'result', function (result) {
           expect(result.success).to.to.eql(false)


### PR DESCRIPTION
The mocha listens for 'test end' event (it can restart test if it is
failed). If an exception is thrown from the setup/beforeEach, the
karma-mocha must not fire 'test end' event, because it leads to
exception inside mocha code (the mocha tries to get current test,
which is undefined).

With this, mocha adapter reports fail directly to karma instead of
raising an intermediate 'test end' event.