### PR TITLE
Add support for full regexp --grep arguments

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -176,6 +176,17 @@ var createMochaReporterConstructor = function (tc, pathname) {
     })
   }
 }
+
+var buildGrepExpressionFromString = function (expression) {
+  if (typeof expression !== 'string') {
+    return expression
+  }
+
+  const match = expression.match(/^\/(.*)\/([gimy]+)?$/)
+
+  return match ? new RegExp(match[1], match[2]) : new RegExp(expression)
+}
+
 /* eslint-disable no-unused-vars */
 var createMochaStartFn = function (mocha) {
   /* eslint-enable no-unused-vars */
@@ -188,14 +199,14 @@ var createMochaStartFn = function (mocha) {
       if (Object.prototype.toString.call(clientArguments) === '[object Array]') {
         arrayReduce(clientArguments, function (isGrepArg, arg) {
           if (isGrepArg) {
-            mocha.grep(new RegExp(arg))
+            mocha.grep(buildGrepExpressionFromString(arg))
           } else if (arg === '--grep') {
             return true
           } else {
             var match = /--grep=(.*)/.exec(arg)
 
             if (match) {
-              mocha.grep(new RegExp(match[1]))
+              mocha.grep(buildGrepExpressionFromString(match[1]))
             }
           }
           return false

--- a/test/src/adapter.spec.js
+++ b/test/src/adapter.spec.js
@@ -409,6 +409,16 @@ describe('adapter mocha', function () {
       expect(this.mockMocha.grep.getCall(0).args).to.deep.eq([/test test/])
     })
 
+    it('should pass full regex grep arguments to mocha', function () {
+      sandbox.spy(this.mockMocha, 'grep')
+
+      createMochaStartFn(this.mockMocha)({
+        args: ['--grep', '/test test/i']
+      })
+
+      expect(this.mockMocha.grep.getCall(0).args).to.deep.eq([/test test/i])
+    })
+
     it('should pass grep argument to mocha if we called the run with --grep=xxx', function () {
       sandbox.spy(this.mockMocha, 'grep')
 
@@ -417,6 +427,16 @@ describe('adapter mocha', function () {
       })
 
       expect(this.mockMocha.grep.getCall(0).args).to.deep.eq([/test test/])
+    })
+
+    it('should pass full regex grep arguments to mocha when called with --grep=xxx', function () {
+      sandbox.spy(this.mockMocha, 'grep')
+
+      createMochaStartFn(this.mockMocha)({
+        args: ['--grep=/test test/i']
+      })
+
+      expect(this.mockMocha.grep.getCall(0).args).to.deep.eq([/test test/i])
     })
 
     it('should pass grep argument to mocha if config.args contains property grep', function () {


### PR DESCRIPTION
### Motivation

Some IDEs (i.e. WebStorm)  pass a full regexp, including the delimitters, to `karma run` (See [WI-55539](https://youtrack.jetbrains.com/issue/WI-55539)). This will cause the runner to skip all tests instead of applying the pattern.

This PR aims to provide compatibility for this behaviour.

### Example

```bash
karma run --grep=/^some\\.test\\.Suite/
```